### PR TITLE
[Fix/Core] ApiEventManager.OnKill.Publish

### DIFF
--- a/GameServerLib/Handlers/ChampionDeathHandler.cs
+++ b/GameServerLib/Handlers/ChampionDeathHandler.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System;
 using LeagueSandbox.GameServer.Handlers;
 using GameServerLib.GameObjects.AttackableUnits;
+using LeagueSandbox.GameServer.API;
 
 namespace GameServerLib.Handlers;
 
@@ -112,6 +113,8 @@ internal static class ChampionDeathHandler
         UpdateKillerStats(killer);
         killed.KillSpree = 0;
         killed.DeathSpree++;
+
+        ApiEventManager.OnKill.Publish(data.Killer, data);
     }
 
     internal static void NotifyChampionKillEvent(DeathData data)


### PR DESCRIPTION
Rewriting the assist script is not worth it, since I do not have in-depth knowledge of the code base.

@cabeca1143 is already working on rewriting everything, so it’s better to wait on that.

For now I’ve added ApiEventManager.OnKill.Publish so OnKill works again in champion scripts.

This should close:

https://github.com/brian8544/LeagueServer/issues/26

https://github.com/brian8544/LeagueServer/issues/27

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 